### PR TITLE
Fix for crash in siege

### DIFF
--- a/source/MissionSharedLibrary/src/Utilities/Utility.cs
+++ b/source/MissionSharedLibrary/src/Utilities/Utility.cs
@@ -216,6 +216,12 @@ namespace MissionSharedLibrary.Utilities
             agent.Formation = null;
             agent.Controller = Agent.ControllerType.Player;
             agent.Formation = formation;
+
+            // Add HumanAIComponent back to agent after player control to avoid crash
+            // when agent dies while climbing ladder
+            // or when trying to control an agent who was using siege weapon
+            agent.AddComponent(new HumanAIComponent(agent));
+
             if (isUsingGameObject)
             {
                 agent.DisableScriptedMovement();


### PR DESCRIPTION
Fix crash in siege when agent dies climbing ladder or when controlling an agent using siege weapon